### PR TITLE
fix: version error in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/lonegunmanb/azure-verified-module-fix
 
-go 1.21.2
+go 1.21
 
 require (
 	github.com/ahmetb/go-linq/v3 v3.2.0


### PR DESCRIPTION
@lonegunmanb go now complains if patch versions are included in a go.mod

```text
github.com/lonegunmanb/azure-verified-module-fix/avmfix@latest (in github.com/lonegunmanb/azure-verified-module-fix@v0.0.0-20231108123824-e06354e1e538): go.mod:3: invalid go version '1.21.2': must match format 1.23
```